### PR TITLE
Command path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The agent can act as a client or as a server if the host is placed in a group ca
 * `consul_bootstrap_expect`: When `consul_retry_join` is not defined, this provides the number of expected servers in the datacenter.
 * `consul_ui_enabled`: Whether to enable the UI or not, default is false.
 * `consul_node_meta`: This object allows associating arbitrary metadata key/value pairs with the local node, which can then be used for filtering results from certain catalog endpoints.
+* `consul_inventory_group_name`: set to the group name in the inventory file of the consul servers. Default is 'consul'.
+* `consul_install_dir`: Full path to where to install the consul command. Default is `/usr/local/bin`.
 
 ## Bootstrapping
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,6 @@ consul_datacenter: dc
 consul_domain: consul
 consul_ui_enabled: false
 consul_template: config.json.j2
+consul_install_dir: /usr/local/bin
+consul_inventory_group_name: consul
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
   tags: ['consul']
 
 - name: "Check installed consul version"
-  shell: consul version | grep -Po '(?<=Consul v)(\d+.\d+.\d+)'
+  shell: "{{ consul_install_dir }}/consul version | head -1 | sed '1 s/Consul v//'"
   ignore_errors: True
   changed_when: False
   register: consul_installed_version
@@ -37,7 +37,7 @@
 - name: "Unzip consul archive"
   unarchive:
     src: "{{ consul_download.dest }}"
-    dest: /usr/local/bin
+    dest: "{{ consul_install_dir }}"
     copy: no
     owner: root
     group: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,7 @@
 
 - name: "Make sure that unzip is installed"
   package: name=unzip state=present
+  tags: ['consul']
 
 - name: "Unzip consul archive"
   unarchive:

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -33,7 +33,7 @@
 {% if consul_node_meta is defined %}
   "node_meta": {{ consul_node_meta | to_json }},
 {% endif %}
-{% if 'consul' in group_names %}
+{% if consul_inventory_group_name in group_names %}
   "server": true,
 {% if consul_retry_join is defined %}
   "bootstrap_expect": {{ consul_retry_join|length }},


### PR DESCRIPTION
Feature:
  - New variable: `consul_inventory_group_name`. Set this variable to the inventory group of consul servers. Default: `consul`

Fix:
  - New variable: `consul_install_dir`. Setting this variable to the full path of where the `consul` command will be installed. Default: `/usr/local/bin`. Fixes this error:
```
TASK [AerisCloud.consul : Check installed consul version] ****************************************************************************
fatal: [172.16.1.2]: FAILED! => {"changed": false, "cmd": "consul version | grep -Po '(?<=Consul v)(\\d+.\\d+.\\d+)'", "delta": "0:00:00.004599", "end": "2017-06-27 06:02:55.731306", "failed": true, "rc": 1, "start": "2017-06-27 06:02:55.726707", "stderr": "/bin/sh: consul: command not found", "stderr_lines": ["/bin/sh: consul: command not found"], "stdout": "", "stdout_lines": []}
```