### PR TITLE
Get consul package checksum from hashicorp releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ The agent can act as a client or as a server if the host is placed in a group ca
 ## Variables
 
 * `consul_version`: The version of Consul to install.
-* `consul_checksum`: The checksum of the tarball provided by Hashicorp.
 * `consul_bind_address`: The address that should be bound to for internal cluster communications. This is an IP address that should be reachable by all other nodes in the cluster.
 * `consul_advertise_address`: The advertise address is used to change the address that we advertise to other nodes in the cluster. By default, the -bind address is advertised.
 * `consul_client_address`: The address to which Consul will bind client interfaces, including the HTTP, DNS, and RPC servers. By default, this is "127.0.0.1", allowing only loopback connections.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 consul_version: 1.0.0
-consul_checksum: 585782e1fb25a2096e1776e2da206866b1d9e1f10b71317e682e03125f22f479
 consul_platform: linux_amd64
 consul_datacenter: dc
 consul_domain: consul

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,11 +19,28 @@
   register: consul_installed_version
   tags: ['consul']
 
+- name: "Get consul package checksum file"
+  get_url:
+    url: "https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version }}_SHA256SUMS"
+    dest: "/tmp/consul_{{ consul_version }}_SHA256SUMS"
+    owner: root
+    group: root
+    mode: 0644
+  when: consul_installed_version|failed or consul_installed_version.stdout != consul_version
+  tags: ['consul']
+
+- name: "Get consul checksum"
+  shell: "grep consul_{{ consul_version }}_{{ consul_platform }}.zip /tmp/consul_{{ consul_version }}_SHA256SUMS"
+  register: consul_sha256
+  changed_when: false
+  when: consul_installed_version|failed or consul_installed_version.stdout != consul_version
+  tags: ['consul']
+
 - name: "Download consul"
   get_url:
     url: "https://releases.hashicorp.com/consul/{{ consul_version }}/consul_{{ consul_version }}_{{ consul_platform }}.zip"
     dest: "/tmp/consul_{{ consul_version }}_{{ consul_platform }}.zip"
-    sha256sum: "{{ consul_checksum }}"
+    sha256sum: "{{ consul_sha256.stdout.split(' ')|first }}"
     owner: root
     group: root
     mode: 0644


### PR DESCRIPTION
This PR removes the `consul_checksum` option and fetches the checksum dynamically from hashicorp releases.