### PR TITLE
Remove deprecated retry-join options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,8 @@ The agent can act as a client or as a server if the host is placed in a group ca
 * `consul_datacenter`: The datacenter in which the agent is running.
 * `consul_domain`: By default, Consul responds to DNS queries in the "consul." domain. This flag can be used to change that domain. All queries in this domain are assumed to be handled by Consul and will not be recursively resolved.
 * `consul_retry_join`: Addresses of other agents to join upon starting up.
-* `consul_retry_join_ec2`: This is a nested object that allows the setting of EC2-related `-retry-join` options.
-* `consul_retry_join_gce`: This is a nested object that allows the setting of GCE-related `-retry-join` options.
 * `consul_retry_join_wan`: Addresses of other WAN agents to join upon starting up.
-* `consul_bootstrap_expect`: When `consul_retry_join` is not defined, this provides the number of expected servers in the datacenter.
+* `consul_bootstrap_expect`: Number of expected servers in the datacenter. When provided, Consul waits until the specified number of servers are available and then bootstraps the cluster.
 * `consul_ui_enabled`: Whether to enable the UI or not, default is false.
 * `consul_node_meta`: This object allows associating arbitrary metadata key/value pairs with the local node, which can then be used for filtering results from certain catalog endpoints.
 * `consul_inventory_group_name`: set to the group name in the inventory file of the consul servers. Default is 'consul'.

--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -16,12 +16,6 @@
 {% if consul_retry_join is defined %}
   "retry_join": {{ consul_retry_join|to_json }},
 {% endif %}
-{% if consul_retry_join_ec2 is defined %}
-  "retry_join_ec2": {{ consul_retry_join_ec2|to_json }},
-{% endif %}
-{% if consul_retry_join_gce is defined %}
-  "retry_join_gce": {{ consul_retry_join_gce|to_json }},
-{% endif %}
 {% if consul_retry_join_wan is defined %}
   "retry_join_wan": {{ consul_retry_join_wan|to_json }},
 {% endif %}
@@ -35,9 +29,7 @@
 {% endif %}
 {% if consul_inventory_group_name in group_names %}
   "server": true,
-{% if consul_retry_join is defined %}
-  "bootstrap_expect": {{ consul_retry_join|length }},
-{% elif consul_bootstrap_expect is defined %}
+{% if consul_bootstrap_expect is defined %}
   "bootstrap_expect": {{ consul_bootstrap_expect }},
 {% endif %}
   "performance": {


### PR DESCRIPTION
From version `0.9.1`, cloud auto-join options got merged into the `retry-join` options (see: https://www.consul.io/docs/agent/options.html#cloud-auto-joining)

This PR removes `consul_retry_join_ec2` and `consul_retry_join_gce` options and removes the `consul_bootstrap_expect` behaviour of using the length of the `retry_join` array (using cloud auto-join, the array length is 1 independently of the number of servers).