### PR TITLE
Add an option to download consul from a S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The agent can act as a client or as a server if the host is placed in a group ca
 * `consul_reconnect_timeout`: This controls how long it takes for a failed node to be completely removed from the cluster.
 * `consul_reconnect_timeout_wan`: This is the WAN equivalent of the `reconnect_timeout` parameter, which controls how long it takes for a failed server to be completely removed from the WAN pool.
 * `consul_enable_script_checks`: This controls whether health checks that execute scripts are enabled on this agent, and defaults to false so operators must opt-in to allowing these.
+* `consul_s3_source`: Path to a S3 object. If specified, the consul archive will be fetched from this S3 source instead of the hashicorp CDN.
 
 ## Bootstrapping
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,14 +26,14 @@
     owner: root
     group: root
     mode: 0644
-  when: consul_installed_version|failed or consul_installed_version.stdout != consul_version
+  when: consul_s3_source is not defined and (consul_installed_version|failed or consul_installed_version.stdout != consul_version)
   tags: ['consul']
 
 - name: "Get consul checksum"
   shell: "grep consul_{{ consul_version }}_{{ consul_platform }}.zip /tmp/consul_{{ consul_version }}_SHA256SUMS"
   register: consul_sha256
   changed_when: false
-  when: consul_installed_version|failed or consul_installed_version.stdout != consul_version
+  when: consul_s3_source is not defined and (consul_installed_version|failed or consul_installed_version.stdout != consul_version)
   tags: ['consul']
 
 - name: "Download consul"
@@ -44,8 +44,15 @@
     owner: root
     group: root
     mode: 0644
-  register: consul_download
-  when: consul_installed_version|failed or consul_installed_version.stdout != consul_version
+  when: consul_s3_source is not defined and (consul_installed_version|failed or consul_installed_version.stdout != consul_version)
+  tags: ['consul']
+
+- name: "Download consul (s3)"
+  shell: |
+    aws s3 cp \
+      {{ consul_s3_source }} \
+      /tmp/consul_{{ consul_version }}_{{ consul_platform }}.zip
+  when: consul_s3_source is defined and (consul_installed_version|failed or consul_installed_version.stdout != consul_version)
   tags: ['consul']
 
 - name: "Make sure that unzip is installed"
@@ -54,7 +61,7 @@
 
 - name: "Unzip consul archive"
   unarchive:
-    src: "{{ consul_download.dest }}"
+    src: "/tmp/consul_{{ consul_version }}_{{ consul_platform }}.zip"
     dest: "{{ consul_install_dir }}"
     copy: no
     owner: root


### PR DESCRIPTION
This is used to install Consul in China, where major CDN are blocked or restricted (s3, cloudfront, fastly, ...).